### PR TITLE
Renaming perfSONAR roles groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Set up perfSONAR variables by running the defaults.sh script and then editing th
 
 ```
 ./defaults.sh
-vi inventory/group_vars/all/perfsonar/*
+vi inventory/group_vars/ps_*
 ```
 
 Set up individual host variables with the lsregistration.yml template
@@ -55,7 +55,7 @@ ansible all -m ping
 
 Manage PWA users:
 ```
-vi /inventory/group_vars/all/perfsonar/ps_pwa.yml
+vi /inventory/group_vars/ps_pconfig_web_admin.yml
 ansible-playbook \
   --limit 'ps-psconfig-web-admin' --tags 'ps::pwa_users'\
   perfsonar.yml

--- a/defaults.sh
+++ b/defaults.sh
@@ -5,46 +5,44 @@ if [ "$1" == "" ]; then
 else
   directory=$1
 fi
-#echo $directory/group_vars/all/perfsonar/ps_archive.yml
-#exit
 
-mkdir -p $directory/group_vars/all/perfsonar
-mkdir -p $directory/host_vars/
+mkdir -p $directory/group_vars
+mkdir -p $directory/host_vars
 
 wget -q -P $directory -nc \
   https://raw.githubusercontent.com/perfsonar/ansible-playbook-perfsonar/master/inventory/hosts
 
-if ! [ -f $directory/group_vars/all/perfsonar/ps_archive.yml ]; then
+if ! [ -f $directory/group_vars/ps_archive.yml ]; then
   cp roles/ansible-role-perfsonar-archive/defaults/main.yml \
-    $directory/group_vars/all/perfsonar/ps_archive.yml
+    $directory/group_vars/ps_archive.yml
 fi
 
-if ! [ -f $directory/group_vars/all/perfsonar/ps_installer.yml ]; then
+if ! [ -f $directory/group_vars/ps_installer.yml ]; then
   cp roles/ansible-role-perfsonar-installer/defaults/main.yml \
-    $directory/group_vars/all/perfsonar/ps_installer.yml
+    $directory/group_vars/ps_installer.yml
 fi
 
-if ! [ -f $directory/group_vars/all/perfsonar/ps_maddash.yml ]; then
+if ! [ -f $directory/group_vars/ps_maddash.yml ]; then
   cp roles/ansible-role-perfsonar-maddash/defaults/main.yml \
-    $directory/group_vars/all/perfsonar/ps_maddash.yml
+    $directory/group_vars/ps_maddash.yml
 fi
 
-if ! [ -f $directory/group_vars/all/perfsonar/ps_psconfig-publisher.yml ]; then
+if ! [ -f $directory/group_vars/ps_psconfig-publisher.yml ]; then
   cp roles/ansible-role-perfsonar-psconfig-publisher/defaults/main.yml \
-    $directory/group_vars/all/perfsonar/ps_psconfig-publisher.yml
+    $directory/group_vars/ps_psconfig_publisher.yml
 fi
 
-if ! [ -f $directory/group_vars/all/perfsonar/ps_pwa.yml ]; then
+if ! [ -f $directory/group_vars/ps_pwa.yml ]; then
   cp roles/ansible-role-perfsonar-psconfig-web-admin/defaults/main.yml \
-    $directory/group_vars/all/perfsonar/ps_pwa.yml
+    $directory/group_vars/ps_psconfig_web_admin.yml
 fi
 
-if ! [ -f $directory/group_vars/all/perfsonar/ps_testpoint.yml ]; then
+if ! [ -f $directory/group_vars/ps_testpoint.yml ]; then
   cp roles/ansible-role-perfsonar-testpoint/defaults/main.yml \
-    $directory/group_vars/all/perfsonar/ps_testpoint.yml
+    $directory/group_vars/ps_testpoint.yml
 fi
 
-if ! [ -f $directory/group_vars/all/perfsonar/ps_toolkit.yml ]; then
+if ! [ -f $directory/group_vars/ps_toolkit.yml ]; then
   cp roles/ansible-role-perfsonar-toolkit/defaults/main.yml \
-    $directory/group_vars/all/perfsonar/ps_toolkit.yml
+    $directory/group_vars/ps_toolkit.yml
 fi

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -14,14 +14,15 @@ ansible_become=True
 ansible_become_user=root
 #ansible_become_method=su
 
-[ps-testpoints]
+[ps_testpoint]
 
-[ps-toolkits]
+[ps_toolkit]
 
-[ps-archives]
+[ps_archive]
 
-[ps-maddash]
+[ps_maddash]
 
-[ps-psconfig-publishers]
+[ps_psconfig_publisher]
 
-[ps-psconfig-web-admin]
+[ps_psconfig_web_admin]
+

--- a/perfsonar.yml
+++ b/perfsonar.yml
@@ -4,7 +4,7 @@
   tags: 
     - archives
   hosts:
-    - ps-archives
+    - ps_archive
   roles:
     - ansible-role-perfsonar-archive
 
@@ -12,7 +12,7 @@
   tags: 
     - maddash
   hosts:
-    - ps-maddash
+    - ps_maddash
   roles:
     - ansible-role-perfsonar-maddash
 
@@ -20,7 +20,7 @@
   tags: 
     - testpoints
   hosts:
-    - ps-testpoints
+    - ps_testpoint
   roles:
     - ansible-role-perfsonar-testpoint
 
@@ -28,7 +28,7 @@
   tags: 
     - toolkits
   hosts:
-    - ps-toolkits
+    - ps_toolkit
   roles:
     - ansible-role-perfsonar-toolkit
 
@@ -36,7 +36,7 @@
   tags: 
     - psconfig-publishers
   hosts:
-    - ps-psconfig-publishers
+    - ps_psconfig_publisher
   roles:
     - ansible-role-perfsonar-psconfig-publisher
 
@@ -44,7 +44,7 @@
   tags: 
     - psconfig-web-admin
   hosts:
-    - ps-psconfig-web-admin
+    - ps_psconfig_web_admin
   roles:
     - ansible-role-perfsonar-psconfig-web-admin
 


### PR DESCRIPTION
Having the same names for host groups and for variable files makes it possible to define different values for the same variable depending on the group a host belong to (i.e. ps_testpoint vs ps_toolkit).

The `group_vars` files need to be at the top level of the directory and not in the `all` subdir.  Also, using `_` instead of `- ` to conform to Ansible new standards.